### PR TITLE
Avoid naming collisions for namespaced associations

### DIFF
--- a/lib/cached_counts.rb
+++ b/lib/cached_counts.rb
@@ -215,7 +215,7 @@ module CachedCounts
       key_getter = generate_association_counting_hook_key_getter association, attribute_name, options
 
       add_counting_hooks(
-        "#{name.demodulize.underscore}_#{attribute_name}",
+        "#{name.underscore.gsub(%r{/}, '__')}_#{attribute_name}",
         key_getter,
         association.klass,
         options


### PR DESCRIPTION
If a model is counted by two associations with the same unnamespaced class name, then the counting methods defined on that model will conflict.

This PR adds the namespaces of the associated classes to the method names, preventing conflicts.
