### PR TITLE
Replace race_condition_fallback with a default_value_lambda and a value_updater_lambda

### DIFF
--- a/lib/cached_counts/version.rb
+++ b/lib/cached_counts/version.rb
@@ -1,3 +1,3 @@
 module CachedCounts
-  VERSION = "0.0.6"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Motivation: for a herd of requests to different entries in a table, the race condition fallback strategy would cause the table to become unresponsive, as many long-running reads are scheduled.
To avoid such a situation, schedule these reads in a background process. To support that, support passing in a lambda to update the value in the cache. Default value of the lambda more or less preserves the old behavior.