### PR TITLE
Support Redis backend via Readthis gem

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,8 +1,8 @@
 = CachedCounts
 
-A replacement for Rails' counter caches, using memcached.
+A replacement for Rails' counter caches, using memcached or Redis.
 
-Caches counts of models in a scope or association in memcached, and keeps the
+Caches counts of models in a scope or association in memcached or Redis, and keeps the
 cache up to date using incr/decr operations.
 
 You might prefer this gem over Rails' built-in counter caches when:

--- a/incrdecr_cached_counts.gemspec
+++ b/incrdecr_cached_counts.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |s|
   s.authors     = ["David Judd"]
   s.email       = ["david@academia.edu"]
   s.homepage    = "https://github.com/academia-edu/cached_counts"
-  s.summary     = "A replacement for Rails' counter caches using memcached (via Dalli)"
-  s.description = "A replacement for Rails' counter caches using memcached increment & decrement operations, implemented via after_commit hooks and the Dalli gem"
+  s.summary     = "A replacement for Rails' counter caches using memcached (via Dalli or Readthis)"
+  s.description = "A replacement for Rails' counter caches using memcached increment & decrement operations, implemented via after_commit hooks and the Dalli or Readthis gem"
   s.license     = "MIT"
 
   s.files         = `git ls-files`.split("\n")
@@ -20,9 +20,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "rails", ">= 4.0"
-  s.add_dependency "dalli"
 
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "dalli"
+  s.add_development_dependency "readthis"
   s.add_development_dependency "rspec"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "test_after_commit"

--- a/lib/cached_counts.rb
+++ b/lib/cached_counts.rb
@@ -1,5 +1,5 @@
 require 'cached_counts/logger'
-require 'cached_counts/dalli_check'
+require 'cached_counts/cache_check'
 require 'cached_counts/connection_for'
 
 module CachedCounts

--- a/lib/cached_counts/cache_check.rb
+++ b/lib/cached_counts/cache_check.rb
@@ -1,0 +1,7 @@
+if defined?(Rails)
+  ActiveSupport.on_load :cached_counts do
+    unless Rails.cache.respond_to?(:dalli) || Rails.cache.respond_to?(:pool)
+      raise "CachedCounts depends on Dalli or Readthis!"
+    end
+  end
+end

--- a/lib/cached_counts/dalli_check.rb
+++ b/lib/cached_counts/dalli_check.rb
@@ -1,5 +1,0 @@
-if defined?(Rails)
-  ActiveSupport.on_load :cached_counts do
-    raise "CachedCounts depends on Dalli!" unless Rails.cache.respond_to?(:dalli)
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ require 'bundler/setup'
 require 'pry'
 require 'active_record'
 require 'rails'
-require 'active_support/cache/dalli_store'
 require 'cached_counts'
 
 ActiveRecord::Base.configurations = YAML::load_file('spec/database.yml')
@@ -13,7 +12,14 @@ if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
   ActiveRecord::Base.raise_in_transactional_callbacks = true
 end
 
-Rails.cache = ActiveSupport::Cache::DalliStore.new("localhost")
+case ENV["CACHE_BACKEND"]
+when /readthis/i
+  require 'readthis'
+  Rails.cache = Readthis::Cache.new
+else
+  require 'active_support/cache/dalli_store'
+  Rails.cache = ActiveSupport::Cache::DalliStore.new
+end
 
 RSpec.configure do |config|
   config.before(:each) do


### PR DESCRIPTION
Nowadays Redis becomes go-to cache solution for newly created Rails app. It's [faster]( http://sorentwo.com/2015/07/20/high-performance-caching-with-readthis.html) and provides other useful functionalities beyond cache.

P.S. Which CI service is in use right? I saw both Circle & Travis configuration but couldn't find building messages.