### PR TITLE
CircleCI: Specify no commands for DB setup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,4 +7,4 @@ dependencies:
     - curl -fsSL https://git.io/v2Ifn | bash
 
 database:
-  override:
+  override: []


### PR DESCRIPTION
With the old settings, Circle would still try to run what appears to be
its default DB setup:

```
  bundle exec rake db:create --trace
```