### PR TITLE
Support mem_cache_store

### DIFF
--- a/lib/cached_counts/dalli_check.rb
+++ b/lib/cached_counts/dalli_check.rb
@@ -1,5 +1,7 @@
 if defined?(Rails)
   ActiveSupport.on_load :cached_counts do
-    raise "CachedCounts depends on Dalli!" unless Rails.cache.respond_to?(:dalli)
+    unless Rails.cache.respond_to?(:dalli) || Rails.cache.instance_variable_get(:@data).is_a?(Dalli::Client)
+      raise "CachedCounts depends on Dalli!"
+    end
   end
 end

--- a/lib/cached_counts/dalli_check.rb
+++ b/lib/cached_counts/dalli_check.rb
@@ -1,6 +1,6 @@
 if defined?(Rails)
   ActiveSupport.on_load :cached_counts do
-    unless Rails.cache.respond_to?(:dalli) || Rails.cache.instance_variable_get(:@data).is_a?(Dalli::Client)
+    unless Rails.cache.respond_to?(:dalli) || (defined?(Dalli::Client) && Rails.cache.instance_variable_get(:@data).is_a?(Dalli::Client))
       raise "CachedCounts depends on Dalli!"
     end
   end


### PR DESCRIPTION
[mem_cache_store](http://api.rubyonrails.org/v5.1/classes/ActiveSupport/Cache/MemCacheStore.html) is a built-in memcache cache store for Rails and which seems more compatible than dalli_store.

ref: rails/rails#21595