### PR TITLE
Add cheap method to try to get cached counts

### DIFF
--- a/lib/cached_counts.rb
+++ b/lib/cached_counts.rb
@@ -158,7 +158,8 @@ module CachedCounts
           association_count_key(id, attribute_name, version)
         end
 
-        define_singleton_method "try_#{attr_name}_counts" do |ids, default=nil|
+        # Try to fetch values for ids from the cache. If it's a miss return the default value
+        define_singleton_method "try_#{attr_name}_counts_for" do |ids, default=nil|
           raw_result = Rails.cache.read_multi(*ids.map{|id| association_count_key(id, attribute_name, version)})
 
           result = {}

--- a/lib/cached_counts.rb
+++ b/lib/cached_counts.rb
@@ -158,6 +158,17 @@ module CachedCounts
           association_count_key(id, attribute_name, version)
         end
 
+        define_singleton_method "try_#{attr_name}_counts" do |ids, default=nil|
+          raw_result = Rails.cache.read_multi(*ids.map{|id| association_count_key(id, attribute_name, version)})
+
+          result = {}
+          ids.each do |id|
+            result[id] = raw_result[association_count_key(id, attribute_name, version)]&.to_i || default
+          end
+    
+          result
+        end
+
         define_singleton_method "#{attr_name}_count_for" do |id|
           new({id: id}, without_protection: true).send("#{attr_name}_count")
         end

--- a/lib/cached_counts/version.rb
+++ b/lib/cached_counts/version.rb
@@ -1,3 +1,3 @@
 module CachedCounts
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
This should allow us to cheaply query the counts for a set of objects. I'm not sure of the best way to test this. I patched my local version of the gem and tested the `try_followers_counts` method which worked fine in that it returned nil on dev as expected.