### PR TITLE
Read from cache with raw: true for Rails 7 compatibility

### DIFF
--- a/incrdecr_cached_counts.gemspec
+++ b/incrdecr_cached_counts.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 5.2"
   s.add_dependency "dalli"
+  s.add_dependency "concurrent-ruby", "1.3.4"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec"

--- a/lib/cached_counts.rb
+++ b/lib/cached_counts.rb
@@ -156,7 +156,7 @@ module CachedCounts
     end
 
     def default_race_condition_fallback_proc(key, relation, options)
-      fallback = Rails.cache.read(key)
+      fallback = Rails.cache.read(key, raw: true)
       fallback = fallback.value if fallback.is_a?(ActiveSupport::Cache::Entry)
 
       -> { fallback }
@@ -176,7 +176,7 @@ module CachedCounts
 
         # Try to fetch values for ids from the cache. If it's a miss return the default value
         define_singleton_method "try_#{attr_name}_counts_for" do |ids, default=nil|
-          raw_result = Rails.cache.read_multi(*ids.map{|id| association_count_key(id, attribute_name, version)})
+          raw_result = Rails.cache.read_multi(*ids.map{|id| association_count_key(id, attribute_name, version)}, raw: true)
 
           result = {}
           ids.each do |id|


### PR DESCRIPTION
Fix for a cache read error that occurred when the Academia app was upgraded to Rails 7 in production.

There is a change in rails 7 that makes it so that you have to read the cache with `raw: true` if you write it with `raw: true`, which this gem does. I fixed some instances of this already in the main Academia app, please see [this PR](https://github.com/academia-edu/academia-app/pull/39761) for more information.

I tested this locally on the Academia line that triggered the error and can confirm that this change fixes the issue and is backwards compatible.

This PR also pins `concurrent-ruby` to `1.3.4` since `1.3.5` is incompatible with versions of Rails under 7.1. The main Academia app does this as well.