### PR TITLE
Check for cache key existence before incrementing or decrementing

### DIFF
--- a/lib/cached_counts.rb
+++ b/lib/cached_counts.rb
@@ -288,23 +288,15 @@ module CachedCounts
     def add_counting_hooks(attribute_name, key_getter, counted_class, options)
       increment_hook = "increment_#{attribute_name}_count".to_sym
       counted_class.send :define_method, increment_hook do
-        if (key = instance_exec &key_getter)
-          Rails.cache.increment(
-            key,
-            1,
-            initial: nil # Increment only if the key already exists
-          )
+        if (key = instance_exec &key_getter) && Rails.cache.exist?(key, raw: true)
+          Rails.cache.increment(key)
         end
       end
 
       decrement_hook = "decrement_#{attribute_name}_count".to_sym
       counted_class.send :define_method, decrement_hook do
-        if (key = instance_exec &key_getter)
-          Rails.cache.decrement(
-            key,
-            1,
-            initial: nil # Decrement only if the key already exists
-          )
+        if (key = instance_exec &key_getter) && Rails.cache.exist?(key, raw: true)
+          Rails.cache.decrement(key)
         end
       end
 

--- a/lib/cached_counts/version.rb
+++ b/lib/cached_counts/version.rb
@@ -1,3 +1,3 @@
 module CachedCounts
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
# Issue
~~As far as I can tell, `initial: nil` was never a valid option nor a way to check for key existence before incrementing or decrementing; maybe it was an older option, but I couldn't find any evidence of that~~ (according to @patbl's this was a valid option in `Dalli`, but not `MemCacheStore`). Prior to Rails 7.1, `increment` on missing keys wouldn't result in a new cache value despite this incorrect option. The default `Rails.cache.increment` behavior in 7.1 now appears to be to initialize a key if it doesn't exist and set it to 1.

[v7.0 increment doc](https://api.rubyonrails.org/v7.0.4/classes/ActiveSupport/Cache/MemCacheStore.html#method-i-increment)
[v7.1 increment doc](https://api.rubyonrails.org/v7.1.3/classes/ActiveSupport/Cache/MemCacheStore.html#method-i-increment)

## Reproduction
To reproduce and to confirm the fix works as expected:
* Select a model and an association cached with this library. To see the issue clearly, this model should already have a few relevant association records; create them if they don’t exist already.
* Delete the relevant cache key: `Rails.cache.delete("<Model>:<id>:<plural_association>_count:1")`. Do not invoke any code that reads the cache value yet. 
* Create a new associated record. This will cause `Rails.cache.increment` to be called without an initial value.
* Check the cached value manually or through the model method `<Model>.<plural_association>_count` and compare it to the actual value.
